### PR TITLE
#82 Translation message Account successfuly reactivated in django.po …

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1396,6 +1396,10 @@ msgstr "Mit Passwort bestätigen"
 msgid "Account successfully activated!"
 msgstr "Konto erfolgreich aktiviert!"
 
+#: useroperations/templates/activation.html:13
+msgid "Account successfully reactivated!"
+msgstr "Konto erfolgreich reaktiviert!"
+
 #: useroperations/templates/activation.html:15
 msgid "Activation failed. Please contact an administrator!"
 msgstr ""


### PR DESCRIPTION
…when the account is deleted and reactivated.

@karlbrink 
The reactivation message was the latest change according to Colleague's suggestion. Hence one translation was missing in django.po It can be done directly in production with compilemessages. But might be necessary to merge to master

#: useroperations/templates/activation.html:13
msgid "Account successfully reactivated!"
msgstr "Konto erfolgreich reaktiviert!"